### PR TITLE
Improve disconnect handling

### DIFF
--- a/host_software/config/Cargo.lock
+++ b/host_software/config/Cargo.lock
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -745,9 +745,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "link-cplusplus"
@@ -898,7 +898,7 @@ dependencies = [
 name = "omnixtend_config"
 version = "1.0.0"
 dependencies = [
- "clap 4.0.29",
+ "clap 4.0.32",
  "ctrlc",
  "env_logger 0.10.0",
  "log",
@@ -1093,13 +1093,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettytable-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f375cb74c23b51d23937ffdeb48b1fbf5b6409d4b9979c1418c1de58bc8f801"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
- "atty",
  "csv",
  "encode_unicode",
+ "is-terminal",
  "lazy_static",
  "term",
  "unicode-width",

--- a/host_software/config/Cargo.toml
+++ b/host_software/config/Cargo.toml
@@ -18,7 +18,7 @@ tapasco = { git = "https://github.com/esa-tu-darmstadt/tapasco.git", branch = "m
 log = "0.4.17"
 snafu = "0.7.4"
 env_logger = "0.10.0"
-clap = { version = "4.0.29", features = ["derive"] }
+clap = { version = "4.0.32", features = ["derive"] }
 ctrlc = "3.2.4"
-prettytable-rs = "0.9.0"
+prettytable-rs = "0.10.0"
 pnet = "0.31.0"

--- a/host_software/omnixtend-rs/Cargo.toml
+++ b/host_software/omnixtend-rs/Cargo.toml
@@ -13,7 +13,6 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atomic-option = "0.1.2"
 crossbeam = "0.8.2"
 dashmap = "5.4.0"
 log = "0.4.17"

--- a/host_software/omnixtend-tui/Cargo.lock
+++ b/host_software/omnixtend-tui/Cargo.lock
@@ -38,12 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-option"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,7 +518,6 @@ dependencies = [
 name = "omnixtend-rs"
 version = "1.0.0"
 dependencies = [
- "atomic-option",
  "crossbeam",
  "dashmap",
  "log",

--- a/host_software/omnixtend-tui/src/network.rs
+++ b/host_software/omnixtend-tui/src/network.rs
@@ -40,13 +40,9 @@ impl Drop for Network {
 
 impl Network {
     pub fn new(ifcname: &str) -> Result<Self> {
-        let interface_names_match = |iface: &NetworkInterface| iface.name == ifcname.trim();
-
-        let interfaces = datalink::interfaces();
-        let interface = interfaces
+        let interface = datalink::interfaces()
             .into_iter()
-            .filter(interface_names_match)
-            .next()
+            .find(|iface| iface.name == ifcname.trim())
             .ok_or(Error::InterfaceNotFound {
                 name: ifcname.to_string(),
             })?;
@@ -60,6 +56,7 @@ impl Network {
             Some(m) => m,
             None => MacAddr(0, 0, 0, 0, 0, 1),
         };
+
         let (mut tx, mut rx) = match datalink::channel(&interface, config) {
             Ok(Ethernet(tx, rx)) => (tx, rx),
             Ok(_) => return Err(Error::UnhandledChannelType {}),

--- a/rust_sim/Cargo.lock
+++ b/rust_sim/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-option"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +448,6 @@ checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 name = "omnixtend-rs"
 version = "1.0.0"
 dependencies = [
- "atomic-option",
  "crossbeam",
  "dashmap",
  "log",


### PR DESCRIPTION
- Do not allow requests on already closing/closed connections.
- Replace atomic options with crossbeam channels addressing (addresses CVE-2020-36219).
- Bumps rust dependency versions (addresses GHSA-gfgm-chr3-x6px and closes #3). 